### PR TITLE
Fixed Undefined Index Error In WP 4.1.1

### DIFF
--- a/admin-notice-helper.php
+++ b/admin-notice-helper.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'Admin_Notice_Helper' ) ) {
 		 */
 		public function print_notices() {
 			foreach ( array( 'update', 'error' ) as $type ) {
-				if ( count( $this->notices[ $type ] ) ) {
+				if ( isset($this->notices[ $type ]) && count( $this->notices[ $type ] ) ) {
 					$class = 'update' == $type ? 'updated' : 'error';
 
 					require( dirname( __FILE__ ) . '/admin-notice.php' );


### PR DESCRIPTION
I get the below error when add a single success notice message in wp 4.1.1 

```php
Notice: Undefined index: error in admin-notice-helper.php on line 93
```

* Use Case
Add one single success notice : 
```php 
add_notice( 'Successful' );
 ```
Now Load The Web page. [You Will Get The Error]